### PR TITLE
Two Papers about Code Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Papers about deep learning ordered by task, date. Current state-of-the-art paper
 | DeepCoder: Learning to Write Programs | _7 nov 2016_ | [arxiv](https://arxiv.org/pdf/1611.01989) |  | _None_ | 
 | Neuro-Symbolic Program Synthesis | _6 nov 2016_ | [arxiv](https://arxiv.org/pdf/1611.01855) |  | _None_ | 
 | Deep API Learning | _30 May 2016_ | [arxiv](https://arxiv.org/abs/1605.08535) | | _None_ |
+| DeepAM:Migrate APIs with Multi-modal Sequence to Sequence Learning | _28 Apr 2017_ | [arxiv](https://arxiv.org/abs/1704.07734) | | _None_ |
+
 ### Sentiment Analysis
 
 |Title|Date|Paper|Code|Labels|

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Papers about deep learning ordered by task, date. Current state-of-the-art paper
 | RobustFill: Neural Program Learning under Noisy I/O | _21 mar 2017_ | [arxiv](https://arxiv.org/pdf/1703.07469) |  | _None_ | 
 | DeepCoder: Learning to Write Programs | _7 nov 2016_ | [arxiv](https://arxiv.org/pdf/1611.01989) |  | _None_ | 
 | Neuro-Symbolic Program Synthesis | _6 nov 2016_ | [arxiv](https://arxiv.org/pdf/1611.01855) |  | _None_ | 
+| Deep API Learning | _30 May 2016_ | [arxiv](https://arxiv.org/abs/1605.08535) | | _None_ |
 ### Sentiment Analysis
 
 |Title|Date|Paper|Code|Labels|


### PR DESCRIPTION
Dear Simon

Here are two papers about code generation:

"Deep API Learning" is about generating API invocation sequences from natural language queries.
"DeepAM: Migrate APIs with Multi-modal Sequence to Sequence Learning" is about migrating APIs of programming languages, for example, BufferedReader.read(Java) -> StreamReader.read (C#)

Could you consider and add them to the list?